### PR TITLE
feat(theme): design tokens + PokemonTypeTheme (T-04)

### DIFF
--- a/docs/reviews/architecture-review.md
+++ b/docs/reviews/architecture-review.md
@@ -1,168 +1,85 @@
-# Architecture Review — PR2 (T-03 · Error core)
+# Architecture Review — PR3 (T-04: Theme + Tokens + `PokemonTypeTheme`)
 
-- **Scope:** `lib/core/error/failure.dart`, `lib/core/error/result.dart`, `test/core/error/*`
-- **Branch:** `feature/foundation-part2` → `epic/foundation`
-- **Plan:** `docs/plan/2026-05-24-chore-foundation-setup-plan.md` § "PR2 — Error core"
-- **Architecture:** single-package, feature-first Clean Architecture; `core/` is a transversal **pure leaf**.
-- **Reviewed:** 2026-05-24
+- **Branch:** `feature/foundation-part3` → `epic/foundation`
+- **Scope reviewed:** `lib/core/pokemon/pokemon_type_id.dart`, `lib/app/theme/{app_colors,app_typography,app_theme,pokemon_type_theme}.dart`, `lib/app/app.dart`, and the accompanying tests.
+- **Standards:** single-package feature-first Clean Architecture; `core/` is a transversal leaf; `app/` is app-level wiring/theme; presentation must never be a dependency of domain. Sources of truth: Tech Spec §2 (dependency rule), §3 (layers), §8.2 (entities), §10 (tokens); Plan "PR3 — Theme".
 
 ---
 
-## Summary
+## Dependency Direction & Layer Separation
 
-PR2 adds the typed error vocabulary (`Failure` hierarchy + `Result<T>`) at `lib/core/error/`.
-The placement, dependency direction, and sealed-type design are architecturally sound and match
-the Tech Spec (§7.3 / §8.1) and the approved plan. No upward imports exist; the layer is a true
-leaf. The only non-pure-Dart coupling — `@immutable` from `flutter/foundation` — is justified and
-acceptable for a single-package Flutter app. This review found **no Critical and no Important
-issues**.
+The full intra-package import graph for the changed files (verified with `grep -rn "^import 'package:pokedex"`):
 
----
+```
+main.dart            → app/app.dart
+app/app.dart         → app/theme/app_theme.dart
+app/theme/app_theme  → app/theme/{app_colors, app_typography}
+app/theme/app_typography → app/theme/app_colors
+app/theme/pokemon_type_theme → core/pokemon/pokemon_type_id   ← the only cross-area edge
+core/pokemon/pokemon_type_id → (nothing)
+```
 
-## Critical
+- **`core/` is a clean leaf.** `grep -rn "import 'package:pokedex/app\|import 'package:pokedex/features" lib/core/` returns nothing. `pokemon_type_id.dart` imports nothing at all (not even Flutter) — it is pure Dart, which is exactly what a `core/` leaf consumable by both `app/theme` and a future `features/*/domain` must be.
+- **The one cross-area edge points downward** (`app/theme` → `core/pokemon`), the allowed direction. `core/` never imports `app/` or `features/`, so no cycle is possible. Consistent with Tech Spec §2 ("as setas de dependência apontam sempre para o domínio") and §3's "código realmente transversal … vive em `core/`."
+- **No circular dependencies**, no reverse edges, no duplication of shared code.
 
-_None._
-
----
-
-## Important
-
-_None._
+**Verdict for this section: clean. Zero layer-separation violations.**
 
 ---
 
-## Minor
+## Findings
 
-### M-1 — `Result` is not annotated `@immutable` for symmetry with `Failure`
+### Critical
+None.
 
-- `lib/core/error/result.dart:4` — `Result<T>`, `Ok<T>`, and `Err<T>` are sealed/final with
-  `const` constructors and `final` fields, so they are effectively immutable. But unlike
-  `Failure` (`lib/core/error/failure.dart:9`), they carry no `@immutable` annotation.
-- This is stylistic, not a defect — the classes are already immutable in practice. Adding
-  `@immutable` to `Result` would make the contract explicit and consistent with `Failure`, and
-  the `flutter/foundation` import is already paid for in this package (see S-1). Note: `Ok<T>`
-  holds a `T value` whose runtime instance may itself be mutable, so `@immutable` would be a
-  shallow guarantee — acceptable, and the same caveat the analyzer already tolerates everywhere.
-- **Not blocking.** Leave as-is or annotate; either is defensible.
+### Important
+None.
 
----
+### Minor
 
-## Suggestion
+1. **`core/pokemon/` is the right call, but name the boundary it implies (`core/pokemon/` ≠ domain entities).**
+   `lib/core/pokemon/pokemon_type_id.dart` is sound. The enum is a stable, dependency-free value type with no Flutter import, so it is genuinely transversal — the textbook reason to put something in `core/`. Placing it here instead of `app/theme/` correctly avoids the future `domain → presentation` inversion that would occur if T-14's `Pokemon` entity (`docs/project/02-tech-spec.md:430`) had to import from `app/theme/`. The placement is well-reasoned and the doc comment in the file (`lib/core/pokemon/pokemon_type_id.dart:3-4`) captures the rationale.
+   The risk to flag now: `core/pokemon/` must stay reserved for **transversal, dependency-free** pokemon primitives (ids, enums, small value objects). When the richer `Pokemon`/`PokemonDetail` *entity* (Freezed, business semantics, §8.2) arrives in T-14, it belongs in `features/pokemon_list/domain/`, **not** alongside this enum in `core/pokemon/`. Keeping an entity in `core/` would dissolve the feature-first boundary and let every feature reach domain models transversally. Recommendation: in T-14 the enum can stay in `core/pokemon/` (entities import *down* into it — clean) or migrate into the domain barrel; do **not** let `core/pokemon/` accrete domain entities. A guard-rail for the future PR, not a defect in PR3. (Tech Spec §3, §8.2.)
 
-### S-1 — `@immutable` via `flutter/foundation` is the correct call (assessment, not a change)
+2. **`PokemonTypeStyle` as a `typedef` record (`lib/app/theme/pokemon_type_theme.dart:9`) — the record→class migration for the icon slot is set up correctly, but the record offers no construction control.**
+   The plan's migration path (Plan L294–298) is to promote the record to a class in T-18 carrying the icon, "so call sites keep using `.color` / `.backgroundColor`." Since all access is via named fields (`.color`, `.backgroundColor`) and the only construction site is inside `styleOf` (`pokemon_type_theme.dart:50-56`), the migration to a `final class` will be source-compatible at call sites — the design is right. Minor caveat: a record typedef has no private constructor, so any code can synthesize a `(color: …, backgroundColor: …)` literal and pass it as a `PokemonTypeStyle`, bypassing `styleOf`. Today the only caller is the theme's own test, so exposure is nil. When the type gains an icon and validation in T-18, prefer a `final class` with a private/factory constructor so `styleOf` stays the single source. No change required now. (RN-04, Tech Spec §10.3, Plan L294–298.)
 
-- `lib/core/error/failure.dart:1` imports `package:flutter/foundation.dart` for `@immutable`.
-  The task asked whether this Flutter coupling is acceptable in a leaf that is otherwise pure
-  Dart. **It is, for this project.** Rationale:
-  - This is a **single-package Flutter app**, not a published pure-Dart package. `flutter` is
-    already a direct dependency of the only package; `core/error` will never be extracted or
-    consumed by a Dart-only (server/CLI) target where dragging in Flutter would be a cost.
-  - `@immutable` is an analyzer-only annotation with **zero runtime footprint** — it does not
-    pull Flutter widgets, bindings, or platform channels into the call graph.
-  - Verified `meta` is **not** a direct dependency in `pubspec.yaml`. Reusing the already-present
-    `flutter` SDK dep to source `@immutable` avoids adding `meta` solely for one annotation,
-    which is the leaner choice and matches the plan's incremental-deps / YAGNI posture.
-- **If** this code were ever promoted to a shared pure-Dart package (it is not on the roadmap),
-  the fix is a one-line import swap to `package:meta/meta.dart`. No structural change required.
-  No action needed now.
+3. **`AppTheme.light` maps §10.2 styles to Material text roles, but widgets are also told to reference `AppTypography` directly — pick one canonical path before screen work.**
+   `lib/app/theme/app_theme.dart:17-24` wires six §10.2 styles onto Material `TextTheme` roles, while the doc comment (`app_theme.dart:11-12`) says "widgets may also reference `AppTypography` styles directly." Both are defensible, but two access paths to the same tokens invite drift once T-18 builds real screens (one screen reads `Theme.of(context).textTheme.titleMedium`, another reads `AppTypography.filterTitle`). A presentation-convention question, not a layering violation. Recommendation: choose one canonical access path for T-18 screen code and record it in the UI/theme convention. (Tech Spec §10.2.)
 
-### S-2 — Consider whether `core/error/` will need an `exceptions` slot before T-06
+### Suggestion
 
-- Tech Spec §3 describes `core/error/` as holding "Failure, Result, **exceptions**." PR2 ships
-  `Failure` + `Result` only, which is correct for this slice (no Dio yet). When T-06 maps Dio
-  exceptions → `Failure`, decide deliberately whether intermediate exception types live here or
-  whether the error mapper in `core/network/` consumes Dio's own exceptions directly and emits
-  `Failure`. The current design supports either — flagging only so the §3 "exceptions" note
-  isn't silently dropped. No action this PR.
+4. **The §10.3 "altura" (height-filter) palette and per-type *icon* are correctly out of scope for PR3 — keep them out of `core/`.**
+   Tech Spec §10.3 bundles a height-category palette (Short/Medium/Tall) alongside the type palette. PR3 rightly implements only the type colors (RN-04) and derives the 16 unspecified backgrounds via `Color.lerp(color, white, 0.5)` with an honest comment (`lib/app/theme/pokemon_type_theme.dart:46-49`). When the height palette and the per-type icon arrive (filters feature / T-18), they are presentation concerns and belong in `app/theme/` (icons) or the filters feature, **not** `core/pokemon/`. PR3 sets this up well; this is a marker so the leaf does not become a dumping ground.
+
+5. **Consider a thin `app/theme/theme.dart` barrel before T-18.**
+   Screen code in T-18 will import several theme files. A single barrel (`export 'app_colors.dart'; export 'app_typography.dart'; …`) keeps presentation imports stable and one-directional and avoids each widget reaching into individual theme files. Purely ergonomic; no architectural impact.
 
 ---
 
-## Detailed validation against the task questions
+## Package / Structure Checks
 
-### 1. Is `core/error/` correctly a leaf (no upward imports)?
-
-**Yes.** Verified by scanning all imports in `lib/core`:
-
-- `lib/core/error/failure.dart` imports only `package:flutter/foundation.dart`.
-- `lib/core/error/result.dart` imports only `package:pokedex/core/error/failure.dart` (intra-leaf).
-- No imports of `features/`, `app/`, or any `data` / `domain` / `presentation` path exist
-  anywhere under `lib/core` (`grep` for `features/|app/|presentation|data/|domain/` → none).
-- Inbound check: nothing outside `lib/core/error/` imports the error core yet (expected — its
-  consumers, data/domain, arrive in later layers). No premature coupling.
-
-`core/error` is a genuine transversal pure leaf, exactly as the plan's Technical Considerations
-("`core/error` is leaf") and Tech Spec §3 ("código realmente transversal vive em `core/`") require.
-
-### 2. Is `Result` depending on `Failure` (and not vice-versa) sound?
-
-**Yes — the dependency direction is correct and one-way.**
-
-- `result.dart` → `failure.dart` (`Err.failure` is typed `Failure`). `failure.dart` has **no**
-  reference to `Result`. No cycle.
-- This is the right direction: `Result<T>` is the generic success/error envelope, and the error
-  arm must name a concrete error vocabulary. `Failure` is the more primitive concept (it has
-  meaning independent of `Result`), so it belongs "below." A reverse dependency (`Failure`
-  knowing about `Result`) would be an abstraction inversion. Clean.
-
-### 3. Will this vocabulary serve the later data/domain layers cleanly?
-
-**Yes.** The `Failure` subtypes are a 1:1 transcription of Tech Spec §7.3's Dio→Failure→TE map:
-`NetworkFailure` (TE-01/02), `TimeoutFailure` (TE-06), `NotFoundFailure` (TE-03),
-`ServerFailure` (TE-07), `RateLimitFailure` (TE-08), `ParsingFailure` (TE-09), `CacheFailure`
-(TE-01). The T-06 mapper (`DioExceptionType.connectionError → NetworkFailure`, etc.) will switch
-over Dio exception types and construct these directly — the default-message constructors
-(`const NetworkFailure([super.message = 'offline'])`) make that mapping terse. Use cases
-returning `Result<T>` (Tech Spec §4.1, `call(...) → Result<T>`) compose with `Ok`/`Err` without
-any added abstraction. The vocabulary is complete for the planned data/domain needs and the
-many-to-one TE mapping is documented in the doc comment (`failure.dart:5-6`).
-
-### 4. Is the sealed-type design appropriate for exhaustive handling?
-
-**Yes — this is the canonical reason to use sealed types here.**
-
-- `sealed class Failure` + `final` subtypes (`failure.dart:10`, `:30-69`) and `sealed class
-  Result<T>` + `final Ok`/`Err` (`result.dart:4`, `:10`, `:19`) give the analyzer closed-world
-  knowledge, so `switch` over a `Result`/`Failure` is exhaustiveness-checked at compile time.
-- The test at `test/core/error/result_test.dart:22-30` exercises exactly this — a `switch`
-  expression with no `default`, which only compiles because the hierarchy is sealed. Adding a new
-  `Failure` later will force every exhaustive `switch` to be updated (the desired safety net for
-  the presentation layer's failure→message mapping).
-- `final` (not `base`/`sealed`) on the leaves is appropriate: subtypes are concrete and should
-  not be extended further. Good.
-
-### 5. Equality contract
-
-`Failure` hand-rolls `==`/`hashCode` over `[runtimeType, message]` (`failure.dart:17-25`),
-matching the plan's pinned contract. Using `runtimeType` (not `is`) correctly makes
-`NetworkFailure('x') != CacheFailure('x')` even though both map to TE-01 — verified by
-`failure_test.dart:33-36`. Inequality on same-type/different-message is covered
-(`failure_test.dart:29-31`). This is the architecturally important property: `Failure` values are
-comparable, so they flow safely through `Result` into Riverpod `AsyncValue.error` /
-UI-state equality without spurious rebuilds. `Result` itself has no value equality — acceptable,
-since equality is delegated to its payload (`T` or `Failure`) at the use sites that need it.
+- **Single responsibility per file:** `app_colors` (color tokens), `app_typography` (text styles), `app_theme` (ThemeData assembly), `pokemon_type_theme` (per-type resolution) — clean separation, no grab-bag. PASS.
+- **Composition root (`lib/app/app.dart`):** correct. `PokedexApp` is a `StatelessWidget` building `MaterialApp(theme: AppTheme.light, home: const Scaffold())`; `main.dart` only calls `runApp`. Theme is injected at the root (global, satisfying T-04 acceptance). `ProviderScope` is intentionally deferred to T-17 per the plan — no premature wiring. PASS.
+- **Leaf/independence:** `core/pokemon` and `core/error` are independent leaves; `app/theme` depends only down into `core/`. PASS.
+- **Tests beside source** under `test/app/theme/` and `test/core/`. The color-by-type widget test (`test/app/theme/pokemon_type_theme_test.dart`) imports only `app/theme` + `core/pokemon`, mirroring the production dependency direction (no test-only back-edges). PASS.
+- **Tokens centralized in `app/theme/` per §10.** PASS. `SF Pro Display` fonts are declared in `pubspec.yaml` and present under `assets/fonts/`, so the typography references resolve.
+- **Lints:** package inherits `very_good_analysis`; theme holders consistently use `abstract final class … _();` (non-instantiable static holders). PASS.
 
 ---
 
-## Layer Separation
+## Deviation Assessment (the key decision)
 
-- Violations found: **0**
-- Clean files: `lib/core/error/failure.dart`, `lib/core/error/result.dart` (all checked files clean)
+The deliberate deviation — `PokemonTypeId` in `core/pokemon/` rather than under domain per §8.2 — is **architecturally sound and the correct choice for the foundation phase**:
 
-## Dependency Direction
+- It honors the non-negotiable dependency rule. The alternative (enum in `app/theme/`) would force T-14's domain entity `Pokemon { List<PokemonTypeId> types }` (`docs/project/02-tech-spec.md:430`) to import from presentation — a real inversion.
+- `core/` is the defined home for transversal, framework-agnostic code, and this enum qualifies (zero imports, pure Dart). Both `app/theme` (now) and `features/*/domain` (T-14) may depend on it from above with no cycle.
+- It is a documented, intentional departure from §8.2's *literal* placement, recorded in the file and the plan (L280–285, L414–415). §8.2 lists the enum next to entities for narrative convenience; nothing in §2/§3 requires a transversal enum to physically live in a feature's domain folder, and no migration is forced on T-14.
 
-- Direction violations: **0** · Circular dependencies: **0**
-- Clean: `result.dart → failure.dart` (one-way, intra-leaf); `core/error` depends on nothing in
-  `features/`, `app/`, or any layer above it.
-
-## Package / Module Structure
-
-- Single package; `core/error/` is a focused module with one clear responsibility (typed error
-  vocabulary). Test mirror exists at `test/core/error/`. Files are well-sized and YAGNI-correct
-  for the slice (no exceptions/Dio code pulled in early). No unnecessary dependencies.
+Caveat carried forward as Minor #1: keep `core/pokemon/` for primitives only; do not let it absorb domain entities later.
 
 ---
 
 ## Verdict
 
-**Architecture is clean — ready to merge.** No Critical or Important issues; 1 Minor (optional
-`@immutable` on `Result`) and 2 Suggestions, none blocking.
+**Architecture is clean — ready to merge.** Zero critical/important issues; the `PokemonTypeId → core/` decision is correct and well-documented, dependency direction is one-way with `core/` a verified leaf, the composition root is wired correctly, and the record→class icon migration is set up to be source-compatible for T-18. The minor items are forward-looking guard-rails for T-14/T-18, not blockers.

--- a/docs/reviews/code-simplicity-review.md
+++ b/docs/reviews/code-simplicity-review.md
@@ -1,7 +1,7 @@
 ---
-title: "Code Simplicity / YAGNI Review — PR2 (feature/foundation-part2)"
+title: "Code Simplicity / YAGNI Review — PR3 (feature/foundation-part3)"
 date: 2026-05-24
-scope: "lib/core/error/failure.dart, lib/core/error/result.dart, test/core/error/failure_test.dart, test/core/error/result_test.dart"
+scope: "lib/core/pokemon/pokemon_type_id.dart, lib/app/theme/{app_colors,app_typography,app_theme,pokemon_type_theme}.dart, lib/app/app.dart, test/app/theme/pokemon_type_theme_test.dart, test/app/app_boot_test.dart"
 reviewer: claude-sonnet-4-6 (simplicity agent)
 ---
 
@@ -9,11 +9,9 @@ reviewer: claude-sonnet-4-6 (simplicity agent)
 
 ### Core Purpose
 
-Provide the thinnest typed error vocabulary the rest of the app can depend on:
-a `Result<T>` sum type (`Ok` / `Err`) and a `Failure` sealed hierarchy with seven
-concrete subtypes covering every PRD TE code that is a recoverable error (TE-01..09,
-minus the four UI-state codes). No logic, no utilities, no extension methods — pure
-data types plus equality.
+Wire §10 design tokens into a `ThemeData`, define per-type colors and provisional
+backgrounds for all 18 `PokemonTypeId` values, and apply the theme globally. No
+business logic — pure presentational constants and a single accessor.
 
 ---
 
@@ -25,65 +23,127 @@ None.
 
 ### Important
 
-None.
+#### 1. `app_theme.dart:17-24` — `textTheme` slot mapping is speculative for five of six styles
+
+- **File:** `lib/app/theme/app_theme.dart:17-24`
+- **Issue:** The `TextTheme` block maps six `AppTypography` styles to six Material 3 text
+  roles (`displaySmall`, `headlineMedium`, `titleMedium`, `bodyLarge`, `labelMedium`,
+  `labelSmall`). The plan explicitly notes that widgets may also reference `AppTypography`
+  styles directly. No widget consumer exists yet. The mapping therefore needs justification
+  on its own merits — will the badge label widget call `Theme.of(context).textTheme.labelMedium`
+  or `AppTypography.pokemonType`? If the answer is "direct reference", the `textTheme` entries
+  are pre-wired for consumers that may never arrive, which is a speculative coupling.
+- **Why this is Important rather than Critical:** the plan-mandated reason for `AppTypography`
+  existing ahead of consumers is explicit and accepted. The issue is narrower: the
+  *slot assignments* (which Material role gets which style) are an arbitrary commitment made
+  without a consumer to validate them. A future widget written against `textTheme.labelMedium`
+  for the badge label is now locked to that choice even if it turns out `labelSmall` would
+  have been closer or a custom `DefaultTextStyle` would have been cleaner. There is also a
+  concrete mismatch to note: `displaySmall` is canonically used for large display text at
+  the top of a screen — mapping `applicationTitle` (32 sp, Bold) there is reasonable. But
+  `headlineMedium` for `pokemonName` (26 sp) and `titleMedium` for `filterTitle` (16 sp,
+  Bold) are debatable; `titleLarge` is the conventional Material 3 slot for bold section
+  titles and `headlineMedium` is usually reserved for content-level headings, not a card
+  overlay label. These role choices are not wrong in isolation, but they were made without
+  a Figma-to-M3 mapping document backing them, and changing them after widgets are wired
+  would require touching every call site.
+- **Suggested mitigation:** Either (a) add a brief inline comment per slot explaining why
+  that Material role was chosen (e.g. `// M3 displaySmall ≈ large hero text — closest to
+  applicationTitle`), so the mapping is documented rather than implicit; or (b) defer the
+  `textTheme` wiring until the first widget consumer arrives (T-18 / badge), leaving only
+  `fontFamily` and `colorScheme` in `AppTheme.light` now, with `AppTypography` referenced
+  directly at call sites. Option (b) is the more YAGNI-faithful path and removes the risk
+  of locking in wrong slot assignments before there is evidence they are right.
+- **Estimated saving (option b):** removes 6 lines from `app_theme.dart`; `AppTypography`
+  itself stays (it is wired into the theme via `fontFamily` and used directly later).
 
 ---
 
 ### Minor
 
-#### 1. `failure.dart:3-8` — base-class doc comment partially restates itself
+#### 2. `app_colors.dart:24` — opacity comment states what the code already shows
 
-- **File:** `lib/core/error/failure.dart:3-8`
-- **Issue:** The doc comment opens with "Base type for all typed, recoverable errors in
-  the app." — genuinely useful. The second sentence, "The mapping is many-to-one — e.g.
-  both [NetworkFailure] and [CacheFailure] surface TE-01," is also load-bearing context.
-  The third sentence, "[message] is a short, internal tag (not user-facing); the
-  presentation layer maps each failure to a friendly, localized message," partially
-  duplicates the inline doc on the `message` field two lines below (`lib/core/error/failure.dart:14`):
-  `/// A short, internal description of the failure (not user-facing).`
-  The "not user-facing" qualifier is stated in both places; the "presentation layer maps
-  it" half does add context the field comment lacks.
-- **Suggestion:** Trim the class-level sentence to only the part the field comment cannot
-  carry: remove "not user-facing" from the class comment (the field comment already says
-  it) and keep the "presentation layer maps each failure" clause. The duplication is minor
-  and the comment body is otherwise excellent — this is purely cosmetic.
-- **Estimated saving:** 1 phrase; net impact is negligible.
+- **File:** `lib/app/theme/app_colors.dart:24`
+- **Issue:** `/// Modal scrim over sheets. §10.1 specifies black with an unspecified opacity;
+  this uses the Material barrier default (54%).` The "54%" figure is derivable from the
+  `0x8A` alpha channel in `Color(0x8A000000)` (`0x8A / 0xFF ≈ 54.1%`). The comment adds
+  the rationale ("Material barrier default") which is genuinely useful, but the "54%"
+  restatement is redundant once you know `0x8A` is the canonical Material barrier value.
+- **Suggestion:** Trim to: `/// Modal scrim over sheets (§10.1 black; alpha = Material
+  barrier default 0x8A).` — keeps the rationale, drops the redundant percentage.
+- **Estimated saving:** one phrase; cosmetic.
 
-#### 2. `result_test.dart:8-11` — explicit `<int>` type argument on `Ok` is redundant
+#### 3. `app_colors.dart:5` — `const AppColors._()` private constructor is unreachable
 
-- **File:** `test/core/error/result_test.dart:8`
-- **Issue:** `const result = Ok<int>(42)` — the `<int>` annotation is inferred by Dart
-  from the literal `42`. The explicit annotation adds no safety here because both the
-  `isA<Result<int>>()` assertion and the value check would catch a type mismatch at
-  compile time regardless.
-- **Contrast:** `const result = Err<int>(failure)` on line 16 is in the same position
-  but the annotation there is arguably worthwhile because `failure` is typed `NetworkFailure`
-  (a `Failure`, not an `int`), so the `<int>` is the only place the success-type is
-  expressed — removing it would lose that signal. Line 16 should be kept.
-- **Suggestion:** Drop `<int>` on line 8: `const result = Ok(42)`. The test reads the
-  same; no information is lost.
+- **File:** `lib/app/theme/app_colors.dart:5`
+- **Issue:** `abstract final class AppColors` with `const AppColors._()` — the `abstract`
+  modifier already prevents instantiation; the private constructor is unreachable dead code.
+  The same pattern appears in `AppTypography` (`app_typography.dart:7`) and `AppTheme`
+  (`app_theme.dart:8`) and `PokemonTypeTheme` (`pokemon_type_theme.dart:14`).
+- **Context:** This is an idiomatic Dart pattern used by some teams as an explicit signal
+  that no subclassing is intended. However, `abstract final` already communicates both
+  prohibitions — `abstract` blocks instantiation and `final` blocks extension. The private
+  constructor adds no enforcement beyond what the class modifiers already provide, and it
+  will never be called.
+- **Suggestion:** Remove the four `const ClassName._()` constructors across the four
+  token-namespace classes. The resulting classes remain uninstantiable and non-extensible.
+  This is a minor style preference; if the team treats this constructor as a deliberate
+  namespace-signal convention, keep it and add a shared comment explaining the convention
+  once rather than four silent copies.
+- **Estimated saving:** 4 lines; zero functional impact.
+
+#### 4. `pokemon_type_theme_test.dart:31` — uniqueness assertion partially duplicates the map definition
+
+- **File:** `test/app/theme/pokemon_type_theme_test.dart:31`
+- **Issue:** `expect(colors, hasLength(18))` verifies that all 18 `styleOf` calls return
+  distinct `Color` values. This is a useful guard against copy-paste errors in `_colors`.
+  However, the same test also calls `expect(PokemonTypeId.values, hasLength(18))` on
+  line 30 — this asserts the enum count, which is a compile-time fact. If the enum gains a
+  19th value, the compiler enforces that `_colors` handles it (because `_colors[type]!`
+  would throw at runtime on the missing entry, and the uniqueness test would catch a
+  duplicate). The enum-length assertion provides no additional safety.
+- **Suggestion:** Remove `expect(PokemonTypeId.values, hasLength(18))` (line 30). The
+  colors-set length assertion on line 31 is sufficient: if a new type is added without a
+  color entry the `!` force-unwrap throws; if two types share a color the set shrinks. The
+  18-hard-code in `hasLength(18)` would also become a maintenance burden every time a type
+  is added.
+- **Estimated saving:** 1 line.
 
 ---
 
 ### Suggestions
 
-#### 3. `failure_test.dart:34` — inline comment is the only place the TE-01 sharing is called out in tests
+#### 5. `pokemon_type_theme.dart` — `_exactBackgrounds` map with two entries could be inlined
 
-- **File:** `test/core/error/failure_test.dart:34`
-- **Issue:** `// NetworkFailure and CacheFailure both map to TE-01 but are distinct.`
-  This is a good comment — it explains *why* the test exists (two types sharing a TE
-  code must still be unequal). It is not redundant. No action needed; included here
-  only to confirm it was evaluated and found to be load-bearing.
+- **File:** `lib/app/theme/pokemon_type_theme.dart:40-43`
+- **Issue:** `_exactBackgrounds` is a `const Map` with exactly two entries (Grass and Fire).
+  It exists solely to feed the `??` lookup in `styleOf`. The two entries could be expressed
+  as a direct `if` branch without a map allocation:
+  ```dart
+  final backgroundColor = switch (type) {
+    PokemonTypeId.grass => const Color(0xFF8BBE8A),
+    PokemonTypeId.fire  => const Color(0xFFFFA756),
+    _                   => Color.lerp(color, const Color(0xFFFFFFFF), 0.5)!,
+  };
+  ```
+  This removes the private map, makes the two exact values immediately visible alongside
+  the derivation formula, and avoids a map lookup for the common case (16 out of 18 types
+  hit the `_` branch). The resulting code is 1 line shorter and reads as a single decision.
+  The switch expression is also more obviously exhaustive than a nullable map lookup with a
+  `??` fallback.
+- **Note:** This is a suggestion, not a demand — the current structure is clear and the
+  map will grow to 18 entries once T-18 reconciles backgrounds. If that growth is expected
+  soon, inlining now and re-extracting later adds churn. Given T-18 is planned, keeping the
+  map as a holding area for the reconciled values is defensible.
 
-#### 4. `result.dart` — no `==`/`hashCode` on `Ok`/`Err` is a deliberate omission, not a gap
+#### 6. `app_boot_test.dart:4` — `app_colors` import is used for a single constant assertion
 
-- **File:** `lib/core/error/result.dart`
-- **Issue:** Deliberately absent per the plan's "props = [runtimeType, message] on
-  Failure base only; Ok/Err intentionally have none" decision. Calling this out
-  explicitly so future reviewers do not add value-equality to `Ok`/`Err` speculatively —
-  structural equality on a wrapper carrying an arbitrary `T` would require `T: Equatable`
-  or be silently identity-based, which is worse than no `==` at all. The omission is
-  correct.
+- **File:** `test/app/app_boot_test.dart:4`
+- **Issue:** `import 'package:pokedex/app/theme/app_colors.dart'` is imported to assert
+  `app.theme!.scaffoldBackgroundColor == AppColors.backgroundWhite` (line 16). This is a
+  good assertion — it verifies the theme is wired correctly, not just that it is non-null.
+  The import is justified; noted here only to confirm it was evaluated and found to be
+  load-bearing. No action needed.
 
 ---
 
@@ -91,33 +151,34 @@ None.
 
 None confirmed. The following were evaluated and ruled out:
 
-- **Seven `Failure` subtypes** — all required by the PRD TE mapping. No subtype is
-  speculative; each has a concrete trigger callout in its doc comment (e.g.
-  `DioExceptionType.connectionError`, HTTP status codes). Keep.
-- **Optional `message` parameter on every subtype** — the default messages satisfy the
-  plan's §7.3 requirement; the optional override is needed at T-06 when repository code
-  passes a structured message from the network layer (e.g. the raw HTTP status line).
-  Not YAGNI.
-- **`@immutable` on `Failure`** — prevents mutable subclass accidents at zero runtime
-  cost. Correct use of the annotation; not over-engineering.
-- **`const Result()` base constructor** — enables `const Ok(...)` / `const Err(...)`
-  at call sites. Used in both test files already (`const Ok<int>(42)`,
-  `const Err<int>(failure)`). Keep.
-- **`identical` short-circuit in `==`** — standard Dart equality idiom for sealed
-  value types; adds one branch that is hit whenever the same const instance is compared
-  to itself. The alternative (removing it) would be a micro-pessimization with no
-  clarity benefit.
+- **All 18 `PokemonTypeId` enum values** — the full set is §8.2-mandated; every value has
+  a corresponding `_colors` entry and is exercised by the uniqueness test. Not YAGNI.
+- **`typedef PokemonTypeStyle`** — plan-mandated; the `(color, backgroundColor)` record
+  shape is the deliberate T-18 migration anchor. The comment calling out the T-18 promotion
+  path is load-bearing context, not rot. Keep.
+- **`AppTypography` ahead of widget consumers** — deliberate token-library decision per
+  plan. `AppTypography` is wired into `AppTheme.light` via `textTheme` (see Important §1
+  above for the slot-mapping concern, which is separate from whether the class belongs here).
+- **18 enum value `///` doc comments** — required by `public_member_api_docs`. Not
+  over-engineering; the linter enforces them.
+- **`abstract final class` with static const members** — intended namespace pattern per
+  deliberate decisions. Not over-engineering.
+- **`PokemonTypeId` in `core/` rather than `app/theme/`** — deliberate placement to avoid
+  the domain→presentation dependency inversion at T-14. Correct and documented.
 
 ---
 
 ### Final Assessment
 
-**Total potential LOC reduction:** 1 phrase in a doc comment + 1 type argument in a
-test. Effectively zero.
+**Total potential LOC reduction:** ~12 lines (6 from deferring `textTheme` wiring,
+4 from removing unreachable private constructors, 1 from the redundant enum-length
+assertion, 1 from trimming the modal scrim comment). The `_exactBackgrounds` refactor
+(suggestion §5) is a wash on lines but improves local readability.
 
-**Complexity score:** Low — this is among the simplest possible implementations of a
-typed result type in Dart. The hand-rolled approach is leaner than any macro-generated
-equivalent would be at this size.
+**Complexity score:** Low. The token classes are flat static-const bags; the accessor
+is a two-step lookup with a documented fallback; the tests are straightforward.
 
-**Verdict:** Ready to merge. The error core is minimal, correct, and fully covered.
-The two minor findings are cosmetic and should not block the PR.
+**Verdict:** Ready to merge. One important finding (speculative `textTheme` slot mapping)
+is worth addressing before consumers arrive — either document the role rationale inline or
+defer wiring until T-18; it does not block this PR but will be harder to revisit once
+widgets reference `Theme.of(context).textTheme.*` directly.

--- a/docs/reviews/pr-readiness-review.md
+++ b/docs/reviews/pr-readiness-review.md
@@ -1,8 +1,9 @@
-# PR-Readiness Review — PR2 (T-03 · Error core)
+# PR-Readiness Review — PR3 (T-04 · Theme + Tokens + PokemonTypeTheme)
 
-- **Branch:** `feature/foundation-part2` → `epic/foundation`
-- **Scope:** `lib/core/error/failure.dart`, `lib/core/error/result.dart`, `test/core/error/failure_test.dart`, `test/core/error/result_test.dart`
-- **Plan reference:** `docs/plan/2026-05-24-chore-foundation-setup-plan.md` § "PR2 — Error core: `Result<T>` + `Failure` (T-03)"
+- **Branch:** `feature/foundation-part3` → `epic/foundation`
+- **Scope:** `lib/app/theme/{app_colors,app_typography,app_theme,pokemon_type_theme}.dart`, `lib/core/pokemon/pokemon_type_id.dart`, `test/app/theme/pokemon_type_theme_test.dart`, `lib/app/app.dart`, `test/app/app_boot_test.dart`
+- **Plan reference:** `docs/plan/2026-05-24-chore-foundation-setup-plan.md` § "PR3 — Theme: §10 tokens + per-type colors (T-04)"
+- **Tech Spec reference:** `docs/project/02-tech-spec.md` § "10. Tema e Design Tokens"
 - **Reviewed:** 2026-05-24 by PR-readiness automation
 
 ---
@@ -11,7 +12,7 @@
 
 **Verdict: READY TO OPEN PR**
 
-All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatting is clean, static analysis passes with zero issues, no debug artifacts remain, imports are correct, commit hygiene is clean, and test coverage is adequate. No blockers.
+All mechanical checks pass. PR3 (T-04 theme + tokens) is mechanically sound: formatting is clean, static analysis passes with zero issues, **all 26 color values verified against Tech Spec §10 (18 type colors + 8 base colors + 2 background colors) — exact matches**, no debug artifacts remain, imports are correct, commit hygiene is clean, and test coverage is adequate. No blockers.
 
 **Critical issues:** 0  
 **Important issues:** 0  
@@ -26,13 +27,17 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 - **Tool:** `dart format --set-exit-if-changed`
 - **Result:** No files require reformatting
   ```
-  Formatted 4 files (0 changed) in 0.01 seconds.
+  Formatted 6 files (0 changed) in 0.01 seconds.
   ```
 - **Files verified:**
-  - `lib/core/error/failure.dart`
-  - `lib/core/error/result.dart`
-  - `test/core/error/failure_test.dart`
-  - `test/core/error/result_test.dart`
+  - `lib/app/theme/app_colors.dart`
+  - `lib/app/theme/app_typography.dart`
+  - `lib/app/theme/app_theme.dart`
+  - `lib/app/theme/pokemon_type_theme.dart`
+  - `lib/core/pokemon/pokemon_type_id.dart`
+  - `test/app/theme/pokemon_type_theme_test.dart`
+  - `lib/app/app.dart` (modified)
+  - `test/app/app_boot_test.dart` (modified)
 
 ---
 
@@ -43,10 +48,10 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 - **Tool:** `dart analyze --fatal-infos --fatal-warnings`
 - **Result:**
   ```
-  Analyzing core, core...
+  Analyzing theme, pokemon, theme...
   No issues found!
   ```
-- **Coverage scope:** `lib/core/` + `test/core/`
+- **Coverage scope:** `lib/app/theme/`, `lib/core/pokemon/`, `test/app/theme/`, `lib/app/app.dart`, `test/app/app_boot_test.dart`
 
 ---
 
@@ -58,14 +63,16 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 
 | Artifact Type | Search Term | Result |
 | --- | --- | --- |
-| Print statements | `print\|debugPrint` | None found |
+| Print statements | `print\(`, `debugPrint`, `log\(` | None found |
 | Debug flags | `TODO\|FIXME\|HACK\|WIP\|XXX` | None found |
-| Commented-out code | `^[[:space:]]*//` (non-doc) | None found |
+| Commented-out code | Code-like `// return`, `// var`, etc. | None found |
 | Merge conflict markers | `<<<<<<<\|=======\|>>>>>>>` | None found |
+| Test skip/only markers | `.skip`, `.only`, `testWidgets('skip`, `pending` | None found |
 
 **Notes:**
-- All `//` lines in `lib/core/` and `test/core/` are doc comments (`///`) or clarifying test comments, not commented-out code.
+- All `//` lines are doc comments (`///`) or doc comment markers; no commented-out code blocks.
 - No `print` / `debugPrint` / interactive debugging imports.
+- All tests are active (no skipped tests).
 
 ---
 
@@ -74,40 +81,92 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 ✅ **Status: CLEAN**
 
 **Verified:**
-- `lib/core/error/failure.dart` imports only `package:flutter/foundation.dart` for `@immutable` (a direct Flutter dependency). ✓
-- `lib/core/error/result.dart` imports only `package:pokedex/core/error/failure.dart` (internal). ✓
-- Test files import `flutter_test` (dev dependency) and internal `package:pokedex` paths. ✓
-- No banned imports, no transitive-only abuse.
+- `app_colors.dart` → `package:flutter/material.dart` (uses `Color`) ✓
+- `app_typography.dart` → `material.dart`, `app_colors.dart` (uses `TextStyle`, `AppColors.textBlack/Gray/White`) ✓
+- `app_theme.dart` → `material.dart`, `app_colors.dart`, `app_typography.dart` (all used in `ThemeData`) ✓
+- `pokemon_type_theme.dart` → `material.dart`, `pokemon_type_id.dart` (uses `Color`, `PokemonTypeId` enum) ✓
+- `pokemon_type_id.dart` → No imports (self-contained enum) ✓
+- `app.dart` → `material.dart`, `app_theme.dart` (no transitive-only) ✓
+- `app_boot_test.dart` → `material.dart`, `flutter_test`, `app.dart`, `app_colors.dart` (load-bearing for theme assertion) ✓
+- `pokemon_type_theme_test.dart` → `material.dart`, `flutter_test`, `pokemon_type_theme.dart`, `pokemon_type_id.dart` (all used) ✓
 
 **Dependency review:**
-- `@immutable` from `flutter/foundation.dart` is justified for immutable sealed types in a single-package Flutter app.
-- No new external dependencies added (plan specifies "hand-rolled, no extra deps").
+- All imports are direct (no transitive-only abuse).
+- No new external dependencies added; only `package:flutter/material.dart` and internal paths.
+- No banned imports or circular dependencies.
 
 ---
 
-## .gitkeep Management
+## Color Token Fidelity (Highest-Value Check)
 
-✅ **Status: CORRECT**
+✅ **Status: ALL VERIFIED — 26/26 COLORS EXACT**
 
-- ✓ Removed: `lib/core/.gitkeep` (now that `lib/core/error/` contains real files)
-- ✓ Retained: `lib/features/.gitkeep` (features/ remains empty per plan)
+This is the most critical check for PR3, as a single hex typo is a silent defect. **All color values have been verified against Tech Spec §10.**
+
+### §10.1 Base Colors (6 values)
+
+| Token | Tech Spec | Code | Match |
+| --- | --- | --- | --- |
+| Text / Black | `#17171B` | `0xFF17171B` | ✓ |
+| Text / Gray | `#747476` | `0xFF747476` | ✓ |
+| Text / White | `#FFFFFF` | `0xFFFFFFFF` | ✓ |
+| Background / Input | `#F2F2F2` | `0xFFF2F2F2` | ✓ |
+| Background / White | `#FFFFFF` | `0xFFFFFFFF` | ✓ |
+| Background / Modal | `#000000` (54% opacity) | `0x8A000000` | ✓ |
+
+**Location:** `lib/app/theme/app_colors.dart` lines 8–24
+
+### §10.3 Type Colors — All 18 Pokémon Types
+
+| Type | Tech Spec | Code | Match | Type | Tech Spec | Code | Match |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Grass | `#62B957` | `0xFF62B957` | ✓ | Poison | `#A552CC` | `0xFFA552CC` | ✓ |
+| Fire | `#FD7D24` | `0xFFFD7D24` | ✓ | Water | `#4A90DA` | `0xFF4A90DA` | ✓ |
+| Electric | `#EED535` | `0xFFEED535` | ✓ | Bug | `#8CB230` | `0xFF8CB230` | ✓ |
+| Normal | `#9DA0AA` | `0xFF9DA0AA` | ✓ | Flying | `#748FC9` | `0xFF748FC9` | ✓ |
+| Ground | `#DD7748` | `0xFFDD7748` | ✓ | Fairy | `#ED6EC7` | `0xFFED6EC7` | ✓ |
+| Fighting | `#D04164` | `0xFFD04164` | ✓ | Psychic | `#EA5D60` | `0xFFEA5D60` | ✓ |
+| Rock | `#BAAB82` | `0xFFBAAB82` | ✓ | Ghost | `#556AAE` | `0xFF556AAE` | ✓ |
+| Ice | `#61CEC0` | `0xFF61CEC0` | ✓ | Dragon | `#0F6AC0` | `0xFF0F6AC0` | ✓ |
+| Dark | `#58575F` | `0xFF58575F` | ✓ | Steel | `#417D9A` | `0xFF417D9A` | ✓ |
+
+**Location:** `lib/app/theme/pokemon_type_theme.dart` lines 17–36
+
+### §10.3 Background Colors (2 exact + 16 provisional)
+
+| Type | Tech Spec | Code | Match | Note |
+| --- | --- | --- | --- | --- |
+| Grass | `#8BBE8A` | `0xFF8BBE8A` | ✓ | Exact per §10.3 |
+| Fire | `#FFA756` | `0xFFFFA756` | ✓ | Exact per §10.3 |
+| Other 16 | N/A | `Color.lerp(color, 0xFFFFFFFF, 0.5)` | ✓ | Provisional 50% tint per RN-04; reconciled in T-18 |
+
+**Location:** `lib/app/theme/pokemon_type_theme.dart` lines 40–56
 
 ---
 
-## Commit Hygiene
+## Diff Hygiene
 
 ✅ **Status: CLEAN**
 
-**Changeset for PR2:**
-- ✓ **Staged:** `lib/core/.gitkeep` (deletion)
-- ✓ **Untracked (ready to stage):**
-  - `lib/core/error/failure.dart` (new)
-  - `lib/core/error/result.dart` (new)
-  - `test/core/error/failure_test.dart` (new)
-  - `test/core/error/result_test.dart` (new)
-- ✓ **Docs:** Review reports (`docs/reviews/*.md`) updated for PR2 per policy (overwritten with fresh analysis).
+**Changeset for PR3:**
 
-**No stray edits:** All changes align with PR2 scope (T-03 only). No PR1 files re-touched.
+**New files (6):**
+- `lib/app/theme/app_colors.dart` (25 lines)
+- `lib/app/theme/app_typography.dart` (57 lines)
+- `lib/app/theme/app_theme.dart` (26 lines)
+- `lib/app/theme/pokemon_type_theme.dart` (57 lines)
+- `lib/core/pokemon/pokemon_type_id.dart` (59 lines)
+- `test/app/theme/pokemon_type_theme_test.dart` (49 lines)
+
+**Modified files (2):**
+- `lib/app/app.dart`: Added theme import + wiring to `MaterialApp` (+3 lines, no deletions)
+- `test/app/app_boot_test.dart`: Updated test to verify theme is applied (+4 lines, -1 line)
+
+**Documentation updates (2 — per VGV policy):**
+- `docs/reviews/code-simplicity-review.md` (scope updated for PR3)
+- `docs/reviews/vgv-review.md` (scope updated for PR3)
+
+**No stray edits:** All changes align with PR3 scope (T-04 only). No PR1/PR2 files re-touched.
 
 ---
 
@@ -115,19 +174,29 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 
 ✅ **Status: ADEQUATE**
 
-**Test suite for `lib/core/error/`:**
-- `failure_test.dart`: 5 test cases
-  - Default messages per subtype
-  - Custom message override
-  - Equality (same type & message)
-  - Inequality (same type, different message)
-  - Inequality (different types, same message)
-- `result_test.dart`: 3 test cases
-  - `Ok<T>` construction and value access
-  - `Err<T>` construction and failure access
-  - Exhaustive pattern-matching with `switch`
+**Test suite for `lib/app/theme/` and theme integration:**
 
-**Coverage note:** Plan specifies ~100% line coverage for `core/error/`. The test suite exercises all code paths (both Ok & Err branches, all 7 Failure subtypes, equality/hashCode operators). CI collects coverage but does not enforce a threshold in this phase (by design).
+**`pokemon_type_theme_test.dart` (3 test cases):**
+- **Widgettest:** Colors render correctly for type badges
+  - Pumps `ColoredBox` with `styleOf(PokemonTypeId.fire).color`
+  - Asserts Fire color matches spec: `0xFFFD7D24`
+  - Repeats for Water: `0xFF4A90DA`
+  - Verifies Fire ≠ Water (sanity check)
+- **Unit test:** All 18 types resolve to unique badge colors
+  - Collects `styleOf(type).color` for all 18 `PokemonTypeId` values
+  - Verifies set has exactly 18 distinct colors (catches copy-paste errors)
+- **Unit test:** Background colors are exact for Grass/Fire, derived for others
+  - Asserts Grass background = `0xFF8BBE8A` (exact per §10.3)
+  - Asserts Fire background = `0xFFFFA756` (exact per §10.3)
+  - Verifies derived backgrounds are lighter than badge color
+
+**`app_boot_test.dart` (1 test case added):**
+- **Widget test:** PokedexApp composes a themed MaterialApp
+  - Pumps `PokedexApp()` and verifies `MaterialApp` exists
+  - Asserts `app.theme` is not null (theme is wired)
+  - Asserts `scaffoldBackgroundColor` matches `AppColors.backgroundWhite` (theme is applied)
+
+**Coverage note:** All 26 color tokens exercised via test fixtures or theme assertions. No "happy path only" skips; all paths verified.
 
 ---
 
@@ -137,13 +206,16 @@ All mechanical checks pass. PR2 (T-03 error core) is mechanically sound: formatt
 
 | Requirement | Implementation | Status |
 | --- | --- | --- |
-| Sealed `Result<T>` + `Ok`/`Err` | `result.dart`: sealed class + 2 final subtypes | ✓ |
-| Sealed `Failure` hierarchy | `failure.dart`: sealed base + 7 final subtypes | ✓ |
-| Hand-rolled equality | `Failure`: custom `==` and `hashCode` using runtimeType + message | ✓ |
-| Default messages per subtype | Each Failure subtype has `[super.message = '...']` | ✓ |
-| TE code mapping | Doc comments map each failure to TE-01…TE-09 (many-to-one) | ✓ |
-| No extra deps | No freezed, no equatable — plan specifies "hand-rolled" | ✓ |
-| Pattern-matching readiness | `switch (result) { Ok(:value) => ..., Err(:failure) => ... }` compatible | ✓ |
+| §10.1 base color tokens | `app_colors.dart`: 6 `static const Color` values | ✓ |
+| §10.2 text styles | `app_typography.dart`: 6 `static const TextStyle` values | ✓ |
+| §10.3 type colors | `pokemon_type_theme.dart._colors`: 18 `PokemonTypeId` → `Color` entries | ✓ |
+| §10.3 background tints | `pokemon_type_theme.dart._exactBackgrounds`: Grass + Fire exact; 16 others via `Color.lerp` | ✓ |
+| Theme wiring | `app_theme.dart`: single `ThemeData` getter; `app.dart` applies via `theme:` parameter | ✓ |
+| `PokemonTypeId` in `core/` | `pokemon_type_id.dart` in `lib/core/pokemon/` (not `app/theme/`) per plan §3.2 | ✓ |
+| Record accessor | `PokemonTypeStyle` typedef as record; `styleOf(type)` returns `(color, backgroundColor)` | ✓ |
+| T-18 migration anchor | Comment in code notes T-18 will promote `PokemonTypeStyle` to a class with icon | ✓ |
+| 18 enum member docs | `PokemonTypeId` has `///` doc on all 18 values (linter-enforced) | ✓ |
+| No extra deps | No external packages added; only `package:flutter/material.dart` | ✓ |
 
 ---
 
@@ -165,14 +237,54 @@ None.
 
 ---
 
+## Immutability & Class Patterns
+
+✅ **Status: CORRECT**
+
+| File | Pattern | Status |
+| --- | --- | --- |
+| `app_colors.dart` | `abstract final class AppColors { const AppColors._(); static const Color ...` | ✓ (namespace class, all consts) |
+| `app_typography.dart` | `abstract final class AppTypography { const AppTypography._(); static const TextStyle ...` | ✓ (namespace class, all consts) |
+| `app_theme.dart` | `abstract final class AppTheme { const AppTheme._(); static ThemeData get light ...` | ✓ (namespace class, computed getter) |
+| `pokemon_type_theme.dart` | `abstract final class PokemonTypeTheme { const PokemonTypeTheme._(); static const Map<PokemonTypeId, Color> ...` | ✓ (namespace class, const maps + accessor) |
+| `pokemon_type_theme.dart` | `typedef PokemonTypeStyle = ({Color color, Color backgroundColor})` | ✓ (immutable record per plan T-18) |
+
+All classes follow VGV immutability patterns; no mutable state; const constructors enforced.
+
+---
+
+## Deliberate Decisions (Not Defects)
+
+The following implementation choices align with the plan and/or are documented trade-offs:
+
+| Decision | Rationale | Status |
+| --- | --- | --- |
+| `PokemonTypeId` in `core/` not `app/theme/` | Avoids domain→presentation dependency inversion at T-14 | ✓ (per plan) |
+| `Color.lerp` backgrounds for 16 types | T-18 will reconcile against Figma "Background Type" variables; provisional values reduce gaps now | ✓ (documented in code) |
+| `backgroundModal` opacity = `0x8A` (54%) | Material Design 3 barrier default; §10.1 specifies black but not opacity | ✓ (per plan §10.1) |
+| `typedef PokemonTypeStyle` as record | T-18 promotes it to a class with icon; record is deliberate anchor for that migration | ✓ (per plan T-18) |
+| 18 enum member `///` doc comments | Required by VGV `public_member_api_docs` lint | ✓ (linter-enforced) |
+
+---
+
 ## Suggestions
 
-None.
+None (format, analysis, and debug artifact scans are clean; see companion `code-simplicity-review.md` for style suggestions).
 
 ---
 
 ## Final Verdict
 
-**READY TO OPEN PR** — All mechanical checks pass (formatting, analysis, debug artifacts, imports, commit hygiene, coverage, plan conformance). No blockers remain.
+**READY TO OPEN PR** — All mechanical checks pass:
+- ✅ Formatting: 8 files, 0 changes needed
+- ✅ Static analysis: 0 errors, 0 warnings, 0 infos
+- ✅ **Token fidelity: 26/26 colors verified against Tech Spec §10 (exact matches)**
+- ✅ Debug artifacts: None (0 print, TODO, commented code, merge markers, test skips)
+- ✅ Diff hygiene: 6 new files + 2 modified + 2 review updates; no stray edits
+- ✅ Imports: All direct; no transitive-only abuse
+- ✅ Immutability: Correct patterns (abstract final, const, record)
+- ✅ Tests: 4 test cases across 2 files; no skip/only markers
+- ✅ Commit history: Up-to-date with `epic/foundation`
+- ✅ `.gitignore` coverage: Handles generated artifacts (`.g.dart`, `.freezed.dart`, `build/`, `.dart_tool/`)
 
-The PR is mechanically sound and ready to target `epic/foundation`.
+The PR is mechanically sound and ready to target `epic/foundation`. Proceed with confidence.

--- a/docs/reviews/test-quality-review.md
+++ b/docs/reviews/test-quality-review.md
@@ -1,7 +1,7 @@
 ---
-title: "Test Quality Review — PR2 (foundation-part2)"
+title: "Test Quality Review — PR3 (foundation-part3)"
 date: 2026-05-24
-branch: feature/foundation-part2
+branch: feature/foundation-part3
 reviewer: Test Quality Agent (VGV)
 ---
 
@@ -9,13 +9,15 @@ reviewer: Test Quality Agent (VGV)
 
 ### Coverage Summary
 
-- Test run: **Pass** (coverage confirmed at 100% per task context)
-- Coverage: **100% line coverage** of `lib/core/error/`
-  - `lib/core/error/failure.dart`: 14/14 lines hit
-  - `lib/core/error/result.dart`: 3/3 lines hit
-- Files with tests: **2/2**
-  - `lib/core/error/failure.dart` → `test/core/error/failure_test.dart`
-  - `lib/core/error/result.dart` → `test/core/error/result_test.dart`
+- Test run: **Pass** (all tests pass, coverage collected)
+- Coverage: **100% of executable lines** in `lib/app/theme/pokemon_type_theme.dart`
+  - `lib/app/theme/app_colors.dart`: const-only declarations — no instrumentable lines (not a gap)
+  - `lib/app/theme/app_typography.dart`: const-only declarations — no instrumentable lines (not a gap)
+  - `lib/app/theme/app_theme.dart`: single `static get light` getter — covered via `app_boot_test.dart`
+  - `lib/core/pokemon/pokemon_type_id.dart`: pure enum declaration — no instrumentable lines (not a gap)
+- Files with tests: **2/2 executable files**
+  - `lib/app/theme/pokemon_type_theme.dart` → `test/app/theme/pokemon_type_theme_test.dart`
+  - `lib/app/app.dart` (theme wiring) → `test/app/app_boot_test.dart`
 - Missing test files: none
 
 ---
@@ -28,92 +30,112 @@ None.
 
 ### Important
 
-**`test/core/error/failure_test.dart:21-27` — Structural equality path never exercised by the "equal" case**
+**`test/app/theme/pokemon_type_theme_test.dart:46` — derived-tint background assertion is too weak**
 
-The equality test uses two `const` instances of the same type:
-
-```dart
-const a = ServerFailure();
-const b = ServerFailure();
-expect(a, b);
-```
-
-Dart canonicalizes compile-time constants: `a` and `b` are the *identical* object in memory. The hand-rolled `==` operator short-circuits on `identical(this, other)` before reaching the structural comparison (`runtimeType == other.runtimeType && message == other.message`). As a result, the structural equality branch — the part of `==` that is actually hand-written and therefore error-prone — is never exercised by any test case that expects the result to be `true`.
-
-The inequality tests at `failure_test.dart:29-36` do partially exercise the structural path (they reach the `other is Failure` check and then fail on message or type), but no test confirms that the structural branch correctly returns `true` for two non-identical, structurally-equal instances. A bug in that branch — for example, `||` changed to `&&`, or `runtimeType ==` dropped — would be invisible to the current suite.
-
-Fix: add one equality test using non-const-identical instances. The simplest approach is to construct two instances from a runtime value so Dart cannot canonicalize them, or use factory constructors:
+The test for the derived-path background at line 45-46 is:
 
 ```dart
-test('equal instances constructed independently share value equality', () {
-  final message = 'test-${DateTime.now().microsecondsSinceEpoch}';
-  final a = NetworkFailure(message);
-  final b = NetworkFailure(message);
-  // a and b are not identical — structural path is exercised
-  expect(identical(a, b), isFalse);
-  expect(a, b);
-  expect(a.hashCode, b.hashCode);
-});
+final water = PokemonTypeTheme.styleOf(PokemonTypeId.water);
+expect(water.backgroundColor, isNot(water.color));
 ```
 
-This is the one gap between reported line coverage and semantic coverage of the equality contract.
+This only verifies that the derived background is not identical to the badge color. It does not pin what the background color *is*. The production formula is `Color.lerp(color, const Color(0xFFFFFFFF), 0.5)!`. If the formula were accidentally changed — for example, a different lerp fraction, a different target color, or an entirely different derivation — this assertion would continue to pass as long as the result was still different from the badge color.
+
+For water, the expected derived value is computable: `Color.lerp(const Color(0xFF4A90DA), const Color(0xFFFFFFFF), 0.5)!` = `Color(0xFFA4C8ED)`. Asserting this exact value pins the formula and catches any unintended change to the derivation logic, which is the purpose of the test.
+
+This is "important" rather than "critical" because the formula is simple and stable for this phase, and it is explicitly documented as a stopgap pending T-18's Figma reconciliation. However, the plan calls for verifying "the derived-tint background path," and a non-equality check does not constitute verification of the tint — it only verifies non-identity.
+
+Fix: replace the weak `isNot` check with an exact expected value for at least one derived type:
+
+```dart
+// water badge color: Color(0xFF4A90DA)
+// derived: Color.lerp(Color(0xFF4A90DA), white, 0.5) = Color(0xFFA4C8ED)
+expect(
+  PokemonTypeTheme.styleOf(PokemonTypeId.water).backgroundColor,
+  const Color(0xFFA4C8ED),
+);
+```
 
 ---
 
 ### Minor
 
-None.
+**`test/app/theme/pokemon_type_theme_test.dart:8-22` — widget test uses `testWidgets` unnecessarily**
+
+The RN-04 color-by-type test pumps a bare `ColoredBox` into the widget tree solely to read back the color it was constructed with:
+
+```dart
+await tester.pumpWidget(
+  ColoredBox(color: PokemonTypeTheme.styleOf(PokemonTypeId.fire).color),
+);
+final fire = tester.widget<ColoredBox>(find.byType(ColoredBox)).color;
+```
+
+`PokemonTypeTheme.styleOf` is a pure function that returns a record of `Color` values. The widget pump does not exercise any rendering pipeline, layout, or theme resolution — it merely gives a `Color` to `ColoredBox` and then reads it back from the same widget. No widget-specific behavior is being tested.
+
+This is not a correctness problem — the assertions are sound and the test does satisfy the plan's "example widget test" requirement with exact hex values. But it inflates the test surface without exercising widget rendering. A plain `test` calling `PokemonTypeTheme.styleOf` directly would be cleaner and faster. This distinction becomes material in T-18, when actual badge/card widgets should have widget tests that verify the *rendered* color.
+
+This is minor because the plan explicitly called for a widget test as evidence of color-by-type behavior (RN-04), and the test does satisfy that acceptance criterion while remaining non-tautological.
+
+**`test/app/theme/pokemon_type_theme_test.dart:30` — uniqueness test does not assert the resolved values**
+
+The all-18-unique-colors test at lines 24-32 correctly verifies uniqueness by inserting all colors into a `Set` and checking the set has 18 entries. It also confirms `PokemonTypeId.values` has 18 elements. This is a well-structured test.
+
+The minor gap: none of the 16 types not covered by the widget test at lines 8-22 have their exact badge hex asserted anywhere. The uniqueness test guarantees no two types share a color and that all 18 resolve without throwing, but a wrong hex value (e.g. two neighboring entries accidentally swapped) would produce 18 distinct values and pass. Consider spot-checking 2-3 additional types with exact hex assertions — enough to catch copy-paste errors in the color table without asserting all 18.
 
 ---
 
 ### Suggestions
 
-**`test/core/error/failure_test.dart` — hashCode divergence for unequal instances not asserted**
+**`test/app/app_boot_test.dart` — assert `theme` is the correct `AppTheme.light` identity, not just non-null with one property**
 
-The test at `failure_test.dart:21-27` confirms that two equal `Failure` instances share a `hashCode`, which satisfies the contract's positive side. The hand-rolled implementation uses `Object.hash(runtimeType, message)`. While the Dart spec does not require unequal objects to have different hashes (collisions are valid), for a hand-rolled implementation with only two fields, asserting that the hashes *do* differ for the inequality cases documents intent and catches a naive bug (e.g. `hashCode => 0`). This is a suggestion, not a requirement.
+The current global-theme test at lines 15-16 checks:
 
 ```dart
-test('different type or message produce different hashCodes', () {
-  expect(
-    const NetworkFailure('x').hashCode,
-    isNot(const CacheFailure('x').hashCode),
-  );
-  expect(
-    const NetworkFailure('a').hashCode,
-    isNot(const NetworkFailure('b').hashCode),
-  );
-});
+expect(app.theme, isNotNull);
+expect(app.theme!.scaffoldBackgroundColor, AppColors.backgroundWhite);
 ```
 
-**`test/core/error/failure_test.dart:16-18` — Custom message only tested for `NetworkFailure`**
+`scaffoldBackgroundColor` is a meaningful sentinel, and the assertion is not tautological. However, `scaffoldBackgroundColor` is one of the cheaper properties to get right accidentally — any `ThemeData` with default or manually set white background would satisfy it. A stronger (and still simple) assertion would verify the `fontFamily`, which is the most distinctive property of `AppTheme.light`:
 
-Only one subtype is exercised with a custom message. All 7 subtypes share the same `([super.message = '<default>'])` constructor pattern, so this is not a critical gap — the path is covered. However, a brief parametric check across all subtypes (or at least one more subtype) would make the test suite self-documenting: a future reader can confirm that the optional-message pattern compiles and behaves correctly for each type, not just the one used as an example. Low priority given the shared constructor delegate.
+```dart
+expect(app.theme!.textTheme.displaySmall?.fontFamily, 'SF Pro Display');
+```
+
+This is a suggestion rather than a minor issue because `scaffoldBackgroundColor` is a legitimate and specific sentinel tied to `AppColors.backgroundWhite` (`0xFFFFFFFF`), which is already non-trivially specific. The global-theme acceptance criterion is met.
+
+**`test/app/theme/pokemon_type_theme_test.dart` — derived-background test could cover more than one derived type**
+
+Only water is used to exercise the derived-tint path. Given that the plan notes the derivation is a `Color.lerp` stopgap reconciled in T-18, testing two derived types (e.g. water and electric) with exact expected values would make the intent clearer and catch any type-keyed conditional logic that might be introduced inadvertently. Low priority for this phase.
 
 ---
 
 ### Plan Requirement Checklist
 
-| Requirement (from plan PR2 section) | Status |
+| Requirement (from plan PR3 section) | Status |
 |---|---|
-| Construction of `Ok` and `Err` tested | Pass — `result_test.dart:7-19` |
-| `Ok`/`Err` exhaustive switch (pattern-match) tested | Pass — `result_test.dart:22-30` |
-| `Failure` equality of identical instances tested | Pass — `failure_test.dart:21-27` |
-| Inequality: same type, different message | Pass — `failure_test.dart:29-31` |
-| Inequality: different type, same message | Pass — `failure_test.dart:33-36` |
-| Default message for all 7 subtypes asserted | Pass — `failure_test.dart:6-13` |
-| `hashCode` consistency tested | Pass — `failure_test.dart:26` |
-| `~100% line coverage` of `core/error/` | Pass — 100% confirmed |
-| Structural equality path exercised under positive case | **Gap** — const canonicalization means `identical()` short-circuits; structural branch untested for `true` return |
+| `ThemeData` defined with §10.1 base colors + typography | Pass — `app_theme.dart` wired, `app_boot_test.dart:16` asserts `scaffoldBackgroundColor` |
+| `PokemonTypeTheme` covers all 18 types | Pass — `pokemon_type_theme_test.dart:24-32` exhaustively verified via uniqueness Set |
+| All 18 types resolve without throwing | Pass — same test iterates `PokemonTypeId.values` |
+| Exact §10.3 badge hex for grass (color) | Pass — `pokemon_type_theme_test.dart:19` (fire exact hex asserted) |
+| Exact §10.3 badge hex for water (color) | Pass — `pokemon_type_theme_test.dart:20` (water exact hex asserted) |
+| Exact §10.3 background for grass | Pass — `pokemon_type_theme_test.dart:36-39` exact `Color(0xFF8BBE8A)` |
+| Exact §10.3 background for fire | Pass — `pokemon_type_theme_test.dart:40-43` exact `Color(0xFFFFA756)` |
+| Derived-tint background path tested | **Partial** — non-identity checked (`isNot`), but formula not pinned with an exact value (`pokemon_type_theme_test.dart:45-46`) |
+| Color-by-type verified in widget test (RN-04) | Pass — `pokemon_type_theme_test.dart:8-22`, fire and water exact hex asserted, `isNot` confirms distinct values |
+| Theme applied globally (acceptance criterion) | Pass — `app_boot_test.dart:15-16`, `scaffoldBackgroundColor == AppColors.backgroundWhite` asserted |
 
 ---
 
 ### State Management Test Quality
 
-Not applicable. No BLoC/Cubit/Riverpod providers exist in PR2. The first provider lands in T-17.
+Not applicable. No BLoC/Cubit/Riverpod providers exist in PR3. The first provider lands in T-17.
 
 ### UI Component Test Quality
 
-Not applicable. PR2 is pure Dart — no widgets.
+The RN-04 widget test at `test/app/theme/pokemon_type_theme_test.dart:8-22` pumps a `ColoredBox` with exact type-resolved colors and asserts the resolved hex values. It satisfies the plan's "example widget test" requirement. See the Minor note above regarding the use of `testWidgets` for a pure-function result.
+
+The global-theme test at `test/app/app_boot_test.dart` pumps `PokedexApp` and asserts `MaterialApp` presence and `scaffoldBackgroundColor`. This is appropriate and non-tautological.
 
 ---
 
@@ -123,25 +145,25 @@ None detected.
 
 | Check | Result |
 |---|---|
-| Tautological assertion (`expect(true, isTrue)` style) | Not present |
-| Mock-everything (mocking the class under test) | Not applicable — pure Dart, no dependencies to mock |
-| Implementation mirroring | Not present — the `describe` helper in `result_test.dart:23` tests pattern-match expressiveness, not internal logic |
-| No assertions | Not present — all test cases carry meaningful assertions |
+| Tautological assertion | Not present — exact hex values `Color(0xFFFD7D24)` / `Color(0xFF4A90DA)` are specific and non-trivial |
+| Mock-everything | Not applicable — no dependencies to mock |
+| Implementation mirroring | Not present — tests assert spec-defined values, not reproduced logic |
+| No assertions | Not present — all tests carry meaningful assertions |
 | Missing state tests | Not applicable — no state management |
-| Hardcoded magic values without context | Not present — `42` in `result_test.dart:8` is an unambiguous sentinel; `'offline'`, `'404'` etc. are the literal spec-defined defaults |
-| Over-verification (`verify` on every mock) | Not present |
-| Missing async waiting after state changes | Not applicable — synchronous pure-Dart tests |
+| Hardcoded magic values without context | Not present — hex values map directly to §10.3; test names and comments provide context |
+| Over-verification | Not present |
+| Missing async waiting after state changes | Not applicable — `ColoredBox` pump requires no async settling |
 
 ---
 
 ### Recommendations
 
-1. **Add a non-identical equality test to exercise the structural branch of `Failure.==`.** The const-canonicalization issue means the hand-rolled structural equality body (`runtimeType == other.runtimeType && message == other.message`) is only exercised on the *false* side (the inequality tests) and never on the *true* side from a non-identical object pair. One new test case, using a runtime-derived message string to defeat canonicalization, closes this gap without touching production code.
+1. **Pin the derived-tint formula with an exact expected value.** The `isNot(water.color)` check at `pokemon_type_theme_test.dart:46` does not verify what the background color *is*, only what it is not. Replace with `expect(..., const Color(0xFFA4C8ED))` (the computed lerp result for water) to make the test catch any unintended formula change. This is the only substantive gap between the plan's stated verification scope and what the tests actually assert.
 
-2. **All other plan requirements are fully met.** Both files have tests, all 7 default messages are asserted, both inequality axes (same-type-different-message and different-type-same-message) are covered, the exhaustive switch is demonstrated, and `hashCode` consistency is verified. The tests are clean, idiomatic `flutter_test`, and free of the anti-patterns listed above.
+2. **All other plan requirements are fully met.** Both test files exist, both critical acceptance criteria (color-by-type widget test, global theme applied) are asserted with specific values, all 18 types are exhaustively covered for uniqueness and non-throw behavior, and the two spec-exact backgrounds (grass/fire) are pinned with exact hex values. The tests are idiomatic, well-grouped, and free of the anti-patterns listed above.
 
 ---
 
 ### Verdict
 
-Ready to merge after adding one non-identical equality test (`failure_test.dart`) to close the structural-branch gap in the hand-rolled `Failure.==` — one important semantic coverage issue; all other plan requirements are satisfied and the test quality is otherwise high.
+Ready to merge after strengthening the derived-tint background assertion at `pokemon_type_theme_test.dart:46` from a weak `isNot` check to an exact expected `Color` value — one important gap; all other plan requirements are satisfied and test quality is otherwise high.

--- a/docs/reviews/vgv-review.md
+++ b/docs/reviews/vgv-review.md
@@ -1,68 +1,79 @@
-# VGV Code Review — Foundation PR2 (T-03 · Error core)
+# VGV Code Review — Foundation PR3 (T-04 · Theme + design tokens + `PokemonTypeTheme`)
 
-- **Branch:** `feature/foundation-part2` (stacked on merged PR1) → target `epic/foundation`
-- **Scope reviewed:** `lib/core/error/failure.dart`, `lib/core/error/result.dart`, `test/core/error/failure_test.dart`, `test/core/error/result_test.dart`
-- **Source of truth:** `docs/plan/2026-05-24-chore-foundation-setup-plan.md` (PR2 — Error core section), Tech Spec §7.3/§8.1, PRD §8 (TE codes)
+- **Branch:** `feature/foundation-part3` (stacked on merged PR1 + PR2) → target `epic/foundation`
+- **Scope reviewed:** `lib/core/pokemon/pokemon_type_id.dart`, `lib/app/theme/app_colors.dart`, `lib/app/theme/app_typography.dart`, `lib/app/theme/app_theme.dart`, `lib/app/theme/pokemon_type_theme.dart`, `lib/app/app.dart`, `test/app/theme/pokemon_type_theme_test.dart`, `test/app/app_boot_test.dart`
+- **Source of truth:** `docs/plan/2026-05-24-chore-foundation-setup-plan.md` (PR3 — Theme section), Tech Spec §10.1 / §10.2 / §10.3
 - **Reviewed:** 2026-05-24
 
 ## Summary
 
-This is a clean, faithful, well-scoped implementation of the typed error core. The sealed `Failure` hierarchy and `Result<T>` re-express the Tech Spec §7.3/§8.1 sketches exactly, with the planned equality contract (`props = [runtimeType, message]`) hand-rolled correctly on the base class. Doc comments carry the PRD TE-code traceability per the plan, default messages match §7.3's terse internal tags, and `@immutable` is sourced from the already-present `flutter/foundation` rather than adding `meta`. The tests cover construction, default and overridden messages, `Ok`/`Err` exhaustive pattern-matching, and — critically — both equality and the two inequality axes (same-type/different-message, different-type/same-message). `dart analyze lib/core/error test/core/error` returns **No issues found**. All four T-03 acceptance criteria are met. The deliberate, plan-justified decisions (hand-rolled sealed classes, no `==` on `Ok`/`Err`, terse internal messages) are correctly applied and are explicitly NOT flagged below.
+A clean, faithful, well-scoped implementation of the foundation theme slice. All 18 §10.3 badge hexes are transcribed **exactly**; the two exact §10.3 backgrounds (Grass `#8BBE8A`, Fire `#FFA756`) are correct; the provisional 50%-toward-white tint for the other 16 matches the plan's pinned formula. Typography re-expresses §10.2 (sizes/weights) and is mapped into Material 3 text roles while staying directly usable. `PokemonTypeId` is correctly placed in `core/` per the documented, plan-justified deviation, and `PokemonTypeStyle` is a record with a documented T-18 migration path to a class. Token holders use VGV-idiomatic `abstract final class` with a private constructor. `dart analyze` on the changed paths returns **No errors**; the full test suite passes with coverage; the boot test was correctly strengthened to assert the global theme. All three T-04 acceptance criteria are met.
 
-**One process caveat (not a code defect):** as with PR1, the PR2 files are currently **untracked working-tree files** (`git status` shows `?? lib/core/`, `?? test/core/`; `git log epic/foundation..HEAD` shows no T-03 commit). The error-core work is invisible to git/CI until committed. Flagging for parity with the PR1 finding, but the code itself is ship-quality.
+The deliberate, plan/spec-justified decisions listed in the task brief (enum placement in `core/`, record-not-class for the style, provisional white-lerp tints for 16 types, Material-barrier-default modal opacity, per-value enum docs, typography mapped into `textTheme`) are correctly applied and are **not** flagged below.
+
+**Process caveat (not a code defect):** PR3 files are currently untracked / uncommitted working-tree changes (`git status` shows `?? lib/app/theme/`, `?? lib/core/pokemon/`, `?? test/app/theme/`, plus modified `lib/app/app.dart` and `test/app/app_boot_test.dart`; no T-04 commit on the branch). The work is invisible to git/CI until committed. Noted for parity with the PR1/PR2 reviews; the code itself is ship-quality.
 
 ## Critical — Must Fix Before Merge
 
-_None._ The code is correct, analyzer-clean, and meets every T-03 acceptance criterion.
+None.
 
 ## Important — Should Fix
 
-- **(whole PR) — The T-03 deliverables are uncommitted/untracked.**
-  - Evidence: `git status --short` shows `lib/core/` and `test/core/` as `??`; `git log --oneline epic/foundation..feature/foundation-part2` lists no `feat(core)` commit (only the inherited PR1 merge). The error-core files exist on disk but are not part of the branch.
-  - Why: A reviewer pulling the branch, and CI running against the pushed ref, would see no error core and no tests — the acceptance criteria are unmet at the git/CI level even though they pass on disk.
-  - Fix: Stage the specific paths and commit as `feat(core)` per the plan, e.g. `git add lib/core/error test/core/error && git commit -m "feat(core): add typed Result and Failure error core"`. Re-verify with `git log --oneline epic/foundation..HEAD` and `git diff --stat epic/foundation...HEAD`. (Note `lib/core/.gitkeep` is now deletable since `lib/core/error/` carries real files — stage that deletion too.)
+None blocking. The one item worth a deliberate decision before merge (Material 3 surface color) is captured under Minor below because it does not affect the foundation acceptance and has no current consumer; promote it to a tracked T-18 item rather than fixing here.
 
 ## Minor
 
-- **`test/core/error/failure_test.dart:16-18` — the custom-message override is only exercised on `NetworkFailure`.** Every subtype shares the same optional-positional-`super.message` construct, so this is sufficient for both behavior and line coverage (the override path is structurally identical across subtypes; verified `dart analyze` clean and the plan confirms 14/14 failure-file coverage). No action required — duplicating the override test across all seven subtypes would be redundant. Flagging only so the single-subtype choice is on record as intentional, not an omission.
+- **`lib/app/theme/app_theme.dart:13-15` — `ColorScheme.surface` is not the §10.1 `Background / White` (`#FFFFFF`).** `ThemeData` defaults to Material 3 (Flutter 3.44 / SDK `^3.12`), where `Scaffold`, `Card`, `BottomSheet`, `Dialog`, and `AppBar` derive their fills from `colorScheme.surface` / `surfaceContainer*`, **not** from `scaffoldBackgroundColor`. `ColorScheme.light()` ships `surface = #FFFFFBFE` (an off-white M3 tone), so sheets/cards/dialogs will not render pure §10.1 white. `scaffoldBackgroundColor` masks this for the bare `Scaffold` (and the boot test only asserts that field), but the first `showModalBottomSheet`/`Card` in the UI layer will reveal the gap.
+  - Why: §10.1 specifies `Background / White #FFFFFF` for "fundo de telas/sheets". The current theme satisfies it only for the scaffold body, not for the surfaces Material 3 actually uses for sheets/cards.
+  - Fix (when the UI layer lands, e.g. T-18): set `surface` (and the relevant `surfaceContainer*` roles) on the `ColorScheme`, e.g. `ColorScheme.light(surface: AppColors.backgroundWhite, onSurface: AppColors.textBlack)`, and consider `appBarTheme`/`bottomSheetTheme`/`cardTheme` backgrounds. Acceptable to defer, but track it explicitly so it is not silently lost.
 
-- **TE traceability lives only in doc comments, not in code.** Per the plan this is the deliberate design — the Dio→Failure→TE mapping is a T-06 concern, and modeling TE codes as fields now would be premature (YAGNI). The doc comments in `failure.dart:5-8,28-29,35,41,47,53,59,65` correctly carry the PRD mapping for traceability. Correct as-is; noting that the "each Failure maps to its TE code(s)" acceptance criterion is satisfied by documentation + the plan's mapping table, which is the agreed approach.
+- **`lib/app/theme/app_colors.dart:17,24` — `backgroundInput` and `backgroundModal` are defined but unwired (no current consumer).** Confirmed by grep: neither token is referenced outside its own declaration. This is fine for a token-definitions slice, but note that `backgroundModal`'s documented "Material barrier default (54%)" decision is currently inert — the actual scrim is whatever `showModalBottomSheet`/`ModalBarrier` uses at call time, not this constant. When sheets land, wire `backgroundInput` into an `InputDecorationTheme` and either use `backgroundModal` at the `showModalBottomSheet(barrierColor:)` call or drop the token to avoid a divergent source of truth.
+  - Why: an unused styled token that documents a specific behavioral choice can drift from the actual runtime behavior and create false confidence.
+
+- **`lib/app/theme/app_theme.dart:16` + `app_typography.dart:8` — the `'SF Pro Display'` family string is duplicated.** It is a private `_fontFamily` constant in `AppTypography` but a bare string literal in `AppTheme.light`. A future rename touches two places.
+  - Why: single-source-of-truth for tokens; the rest of this slice is exemplary about centralization.
+  - Fix: expose the family from one place (e.g. `AppTypography.fontFamily` or an `AppFonts` constant) and reference it in `ThemeData(fontFamily: ...)`.
+
+- **`pubspec.yaml:42-43` — the Semibold (weight 600) font asset is bundled but never referenced by §10.2 / `AppTypography`.** Every `AppTypography` style uses 400/500/700; 600 is declared in `fonts:` but no token requests it. PR1's stated rationale was to ship only the weights the design uses; 600 currently earns no keep in this slice.
+  - Why: a ~2.3 MB asset with no consumer contradicts the foundation's own font-trimming decision and inflates the web payload.
+  - Fix: either drop the Semibold weight until a §10/Figma token demands it, or add a tracking note that T-18 will introduce a Semibold token. (Out of strict PR3 scope since fonts landed in PR1 — flag, don't block.)
 
 ## Suggestion
 
-- **`lib/core/error/result.dart` — consider a brief class-level note that `Ok`/`Err` intentionally omit `==`.** This is a deliberate, plan-justified decision (§8.1 has no equality; tests pattern-match and read `.value`/`.failure`). A one-line `// No `==` by design — consumers pattern-match; see plan PR2.` would pre-empt a future contributor "helpfully" adding equality and diverging from the spec. Purely optional; the current doc comments are otherwise clear and complete.
+- **`lib/app/theme/app_theme.dart:13` — `static ThemeData get light` rebuilds the `ThemeData` on every access.** `ThemeData` is not const-constructible here, but `MaterialApp` reads `theme` on each build; a getter re-allocates each time. Consider a `static final ThemeData light = _build();` (or a cached late-final) so the instance is created once. Negligible at one call site today; cheap to make idiomatic before more consumers read it.
 
-- **`failure.dart:9` — `@immutable` is well-placed on the sealed base** and correctly inherited by all subtypes. No change needed; mentioned only to confirm the annotation choice (reusing `flutter/foundation` over adding `meta`) is the right call and matches the plan.
+- **`test/app/theme/pokemon_type_theme_test.dart:8-22` — the RN-04 widget test reuses `find.byType(ColoredBox)` across two `pumpWidget` calls.** This works (the second pump replaces the tree) and is correct, but a reader may briefly wonder whether two boxes coexist. A one-line comment, or distinct `Key`s, would make the intent obvious. Optional.
 
-## T-03 Acceptance Verification
+- **`test/app/theme/pokemon_type_theme_test.dart:34-47` — the derived-background assertion only checks `water` is `isNot(water.color)`.** It proves the tint differs from the badge color but not that it equals the pinned `Color.lerp(color, white, 0.5)` formula. A single positive assertion against the computed lerp value (for one type) would lock the documented formula against accidental drift before T-18 reconciles it. Optional, since the formula is explicitly provisional.
 
-Verified against the working tree (NOT committed git state — see Important):
+## Acceptance verification (T-04)
 
-- **`Result<T>` covers typed success and error:** PASS. `Ok<T>(value)` and `Err<T>(failure)` extend `sealed Result<T>`; `result_test.dart:7-20` asserts both carry their payloads and are `isA<Result<int>>`; `result_test.dart:22-30` proves exhaustive `switch` pattern-matching with no default arm (compiler-enforced exhaustiveness).
-- **Each Failure maps to its PRD TE code(s) — many-to-one, TE-01…TE-09:** PASS. All seven subtypes present with §7.3 default messages (`offline`/`timeout`/`404`/`5xx`/`429`/`parse`/`cache`); doc comments map each to its TE code(s), including the shared TE-01 (`NetworkFailure` + `CacheFailure`) and TE-01/02 on `NetworkFailure`. TE-04/05/10/11 correctly excluded as UI states.
-- **Unit tests cover construction + equality/inequality:** PASS. Default messages (`failure_test.dart:6-14`), custom override (`:16-18`), equality + hashCode parity (`:21-27`), same-type/different-message inequality (`:29-31`), different-type/same-message inequality (`:33-36`). Equality contract matches the plan's `props = [runtimeType, message]` exactly.
-- **`core/error/` reaches ~100% line coverage:** PASS (plan-verified: failure 14/14, result 3/3). `Ok.value`, `Err.failure`, the base `==`/`hashCode`, and every subtype constructor are exercised.
+- [x] **`ThemeData` with §10.1 base colors + SF Pro Display typography** — `AppTheme.light` sets `fontFamily: 'SF Pro Display'`, `scaffoldBackgroundColor` = §10.1 white, `onSurface` = §10.1 `#17171B`, and maps §10.2 styles into `textTheme`. (Caveat: `ColorScheme.surface` not white — see Minor; does not block acceptance.)
+- [x] **`PokemonTypeTheme` covers all 18 types with §10.3 colors + derived bg tints** — `_colors` has all 18 enum keys; `styleOf` force-unwraps `_colors[type]!`, so a missing key would throw (and the "18 unique colors" test guards completeness). Exact backgrounds for Grass/Fire; lerp tint for the other 16.
+- [x] **Theme applied globally; color-by-type verified in a widget test** — `app.dart:13` wires `theme: AppTheme.light`; `pokemon_type_theme_test.dart` asserts fire vs water resolve to distinct §10.3 colors (RN-04); `app_boot_test.dart` asserts the global theme is present.
 
-## Equality Correctness Audit
+### §10.3 hex transcription — verified exact (18/18)
 
-The hand-rolled contract on the base `Failure` (`failure.dart:17-25`) is correct:
-- `identical` short-circuit, then `other is Failure && runtimeType == other.runtimeType && message == other.message` — so different subtypes are never equal even with identical messages (verified `:33-36`), and same subtype with different messages is unequal (verified `:29-31`).
-- `hashCode = Object.hash(runtimeType, message)` is consistent with `==` (equal objects → equal hashes; asserted `:21-27`). No hashCode/equals contract violation.
+| Type | §10.3 | impl | Type | §10.3 | impl |
+| --- | --- | --- | --- | --- | --- |
+| grass | `62B957` | ✓ | poison | `A552CC` | ✓ |
+| fire | `FD7D24` | ✓ | water | `4A90DA` | ✓ |
+| electric | `EED535` | ✓ | bug | `8CB230` | ✓ |
+| normal | `9DA0AA` | ✓ | flying | `748FC9` | ✓ |
+| ground | `DD7748` | ✓ | fairy | `ED6EC7` | ✓ |
+| fighting | `D04164` | ✓ | psychic | `EA5D60` | ✓ |
+| rock | `BAAB82` | ✓ | ghost | `556AAE` | ✓ |
+| ice | `61CEC0` | ✓ | dragon | `0F6AC0` | ✓ |
+| dark | `58575F` | ✓ | steel | `417D9A` | ✓ |
 
-## Simplicity Assessment
+Backgrounds: Grass `#8BBE8A` ✓, Fire `#FFA756` ✓ (both exact §10.3). §10.1 base colors and §10.2 sizes/weights also transcribed correctly.
 
-- Lines that could be removed: ~0. Both files are minimal — no speculative helpers (`map`/`fold`/`when` on `Result`, factory constructors, etc.) were added; those belong to the layer that first needs them.
-- Unnecessary abstractions: none. No `freezed`/`equatable` pulled in for two tiny types (plan-justified).
-- YAGNI violations: none. `Result` exposes only `value`/`failure`; no premature combinators.
-- Complexity verdict: Already minimal.
+### Verification performed
 
-## Testing Assessment
-
-- New code with tests: PASS — both `failure.dart` and `result.dart` have dedicated, behavior-focused test files.
-- Test quality: Meaningful. No tautologies; equality is tested across all three relevant axes; pattern-matching exhaustiveness is exercised through real `switch` behavior rather than asserting framework internals.
-- State management test coverage: N/A (no providers in this PR).
-- UI component test coverage: N/A (pure-Dart error core, no widgets).
+- `dart analyze` (MCP) on `lib/app/theme`, `lib/core/pokemon`, `lib/app/app.dart`, `test/app` → **No errors**.
+- Full test suite with coverage (very_good test) → **passed**.
+- Hex / token cross-check against Tech Spec §10.1–§10.3 → all exact.
 
 ---
 
-**Overall verdict: READY TO MERGE (code) — commit the untracked `lib/core/error` + `test/core/error` as a `feat(core)` commit before pushing; zero critical and zero code-level important issues.**
+**Verdict:** Ready to merge — 0 critical, 0 blocking-important issues; minor items (Material 3 `surface`, unwired tokens, font-family duplication, Semibold asset) are defer-to-T-18 / nice-to-have, plus the standard "commit before CI" process caveat.

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:pokedex/app/theme/app_theme.dart';
 
 /// Root application widget.
 class PokedexApp extends StatelessWidget {
@@ -7,6 +8,10 @@ class PokedexApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(title: 'Pokédex', home: Scaffold());
+    return MaterialApp(
+      title: 'Pokédex',
+      theme: AppTheme.light,
+      home: const Scaffold(),
+    );
   }
 }

--- a/lib/app/theme/app_colors.dart
+++ b/lib/app/theme/app_colors.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Base color tokens (Tech Spec §10.1).
+abstract final class AppColors {
+  const AppColors._();
+
+  /// Primary text and numbers.
+  static const Color textBlack = Color(0xFF17171B);
+
+  /// Secondary text: descriptions and labels.
+  static const Color textGray = Color(0xFF747476);
+
+  /// Text rendered on top of a type color.
+  static const Color textWhite = Color(0xFFFFFFFF);
+
+  /// Search-field / input background.
+  static const Color backgroundInput = Color(0xFFF2F2F2);
+
+  /// Screen and sheet background.
+  static const Color backgroundWhite = Color(0xFFFFFFFF);
+
+  /// Modal scrim over sheets. §10.1 specifies black with an unspecified
+  /// opacity; this uses the Material barrier default (54%).
+  static const Color backgroundModal = Color(0x8A000000);
+}

--- a/lib/app/theme/app_theme.dart
+++ b/lib/app/theme/app_theme.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/app/theme/app_colors.dart';
+import 'package:pokedex/app/theme/app_typography.dart';
+
+/// Application [ThemeData] built from the §10 design tokens.
+abstract final class AppTheme {
+  const AppTheme._();
+
+  /// The light theme (the only theme in the MVP).
+  ///
+  /// Sets the §10.1 base colors and the SF Pro Display font family. Widgets use
+  /// the named [AppTypography] styles directly for §10.2 typography.
+  static ThemeData get light => ThemeData(
+    colorScheme: const ColorScheme.light(onSurface: AppColors.textBlack),
+    scaffoldBackgroundColor: AppColors.backgroundWhite,
+    fontFamily: AppTypography.fontFamily,
+  );
+}

--- a/lib/app/theme/app_typography.dart
+++ b/lib/app/theme/app_typography.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/app/theme/app_colors.dart';
+
+/// Text styles on SF Pro Display (Tech Spec §10.2).
+abstract final class AppTypography {
+  const AppTypography._();
+
+  /// The bundled font family used across the app.
+  static const String fontFamily = 'SF Pro Display';
+
+  /// "Pokédex" application title.
+  static const TextStyle applicationTitle = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 32,
+    fontWeight: FontWeight.w700,
+    color: AppColors.textBlack,
+  );
+
+  /// Pokémon name on the detail screen.
+  static const TextStyle pokemonName = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 26,
+    fontWeight: FontWeight.w700,
+    color: AppColors.textBlack,
+  );
+
+  /// Auxiliary / description text.
+  static const TextStyle description = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 16,
+    fontWeight: FontWeight.w400,
+    color: AppColors.textGray,
+  );
+
+  /// Filter sheet titles.
+  static const TextStyle filterTitle = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    color: AppColors.textBlack,
+  );
+
+  /// Pokémon number (#NNN).
+  static const TextStyle pokemonNumber = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    color: AppColors.textBlack,
+  );
+
+  /// Type badge label.
+  static const TextStyle pokemonType = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    color: AppColors.textWhite,
+  );
+}

--- a/lib/app/theme/pokemon_type_theme.dart
+++ b/lib/app/theme/pokemon_type_theme.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:pokedex/core/pokemon/pokemon_type_id.dart';
+
+/// The visual style for a Pokémon type: its badge color and card background
+/// color.
+///
+/// A record for now; T-18 promotes it to a class that also carries the type
+/// icon (so call sites keep using `.color` / `.backgroundColor`).
+typedef PokemonTypeStyle = ({Color color, Color backgroundColor});
+
+/// Resolves per-type colors (RN-04 / Tech Spec §10.3), centralizing type
+/// theming so every badge and card derives its color from one place.
+abstract final class PokemonTypeTheme {
+  const PokemonTypeTheme._();
+
+  /// Badge / icon color per type (§10.3 — all 18 specified).
+  static const Map<PokemonTypeId, Color> _colors = {
+    PokemonTypeId.grass: Color(0xFF62B957),
+    PokemonTypeId.poison: Color(0xFFA552CC),
+    PokemonTypeId.fire: Color(0xFFFD7D24),
+    PokemonTypeId.water: Color(0xFF4A90DA),
+    PokemonTypeId.electric: Color(0xFFEED535),
+    PokemonTypeId.bug: Color(0xFF8CB230),
+    PokemonTypeId.normal: Color(0xFF9DA0AA),
+    PokemonTypeId.flying: Color(0xFF748FC9),
+    PokemonTypeId.ground: Color(0xFFDD7748),
+    PokemonTypeId.fairy: Color(0xFFED6EC7),
+    PokemonTypeId.fighting: Color(0xFFD04164),
+    PokemonTypeId.psychic: Color(0xFFEA5D60),
+    PokemonTypeId.rock: Color(0xFFBAAB82),
+    PokemonTypeId.ghost: Color(0xFF556AAE),
+    PokemonTypeId.ice: Color(0xFF61CEC0),
+    PokemonTypeId.dragon: Color(0xFF0F6AC0),
+    PokemonTypeId.dark: Color(0xFF58575F),
+    PokemonTypeId.steel: Color(0xFF417D9A),
+  };
+
+  /// Exact card-background tints from §10.3. Only Grass and Fire are specified;
+  /// the other 16 are derived in [styleOf].
+  static const Map<PokemonTypeId, Color> _exactBackgrounds = {
+    PokemonTypeId.grass: Color(0xFF8BBE8A),
+    PokemonTypeId.fire: Color(0xFFFFA756),
+  };
+
+  /// The [PokemonTypeStyle] for [type].
+  ///
+  /// For the 16 types without an exact §10.3 background, a provisional tint is
+  /// derived (50% toward white); these are reconciled against the Figma
+  /// "Background Type" variables in T-18.
+  static PokemonTypeStyle styleOf(PokemonTypeId type) {
+    final color = _colors[type]!;
+    final backgroundColor =
+        _exactBackgrounds[type] ??
+        Color.lerp(color, const Color(0xFFFFFFFF), 0.5)!;
+    return (color: color, backgroundColor: backgroundColor);
+  }
+}

--- a/lib/core/pokemon/pokemon_type_id.dart
+++ b/lib/core/pokemon/pokemon_type_id.dart
@@ -1,0 +1,59 @@
+/// The 18 Pokémon types.
+///
+/// Defined in `core/` (not `app/theme/`) so both the theme layer and the later
+/// domain layer can depend on it without inverting the layer dependency rule.
+enum PokemonTypeId {
+  /// The Grass type.
+  grass,
+
+  /// The Poison type.
+  poison,
+
+  /// The Fire type.
+  fire,
+
+  /// The Water type.
+  water,
+
+  /// The Electric type.
+  electric,
+
+  /// The Bug type.
+  bug,
+
+  /// The Normal type.
+  normal,
+
+  /// The Flying type.
+  flying,
+
+  /// The Ground type.
+  ground,
+
+  /// The Fairy type.
+  fairy,
+
+  /// The Fighting type.
+  fighting,
+
+  /// The Psychic type.
+  psychic,
+
+  /// The Rock type.
+  rock,
+
+  /// The Ghost type.
+  ghost,
+
+  /// The Ice type.
+  ice,
+
+  /// The Dragon type.
+  dragon,
+
+  /// The Dark type.
+  dark,
+
+  /// The Steel type.
+  steel,
+}

--- a/test/app/app_boot_test.dart
+++ b/test/app/app_boot_test.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pokedex/app/app.dart';
+import 'package:pokedex/app/theme/app_colors.dart';
 
 void main() {
-  testWidgets('PokedexApp boots and composes a MaterialApp', (tester) async {
+  testWidgets('PokedexApp boots and composes a themed MaterialApp', (
+    tester,
+  ) async {
     await tester.pumpWidget(const PokedexApp());
 
     expect(find.byType(MaterialApp), findsOneWidget);
+
+    final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
+    expect(app.theme, isNotNull);
+    expect(app.theme!.scaffoldBackgroundColor, AppColors.backgroundWhite);
   });
 }

--- a/test/app/theme/pokemon_type_theme_test.dart
+++ b/test/app/theme/pokemon_type_theme_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pokedex/app/theme/pokemon_type_theme.dart';
+import 'package:pokedex/core/pokemon/pokemon_type_id.dart';
+
+void main() {
+  group('PokemonTypeTheme', () {
+    testWidgets('colors a widget by its Pokémon type (RN-04)', (tester) async {
+      await tester.pumpWidget(
+        ColoredBox(color: PokemonTypeTheme.styleOf(PokemonTypeId.fire).color),
+      );
+      final fire = tester.widget<ColoredBox>(find.byType(ColoredBox)).color;
+
+      await tester.pumpWidget(
+        ColoredBox(color: PokemonTypeTheme.styleOf(PokemonTypeId.water).color),
+      );
+      final water = tester.widget<ColoredBox>(find.byType(ColoredBox)).color;
+
+      expect(fire, const Color(0xFFFD7D24));
+      expect(water, const Color(0xFF4A90DA));
+      expect(fire, isNot(water));
+    });
+
+    test('resolves a unique badge color for all 18 types', () {
+      final colors = {
+        for (final type in PokemonTypeId.values)
+          PokemonTypeTheme.styleOf(type).color,
+      };
+
+      expect(PokemonTypeId.values, hasLength(18));
+      expect(colors, hasLength(18));
+    });
+
+    test('backgrounds: exact §10.3 for grass/fire, derived tint otherwise', () {
+      expect(
+        PokemonTypeTheme.styleOf(PokemonTypeId.grass).backgroundColor,
+        const Color(0xFF8BBE8A),
+      );
+      expect(
+        PokemonTypeTheme.styleOf(PokemonTypeId.fire).backgroundColor,
+        const Color(0xFFFFA756),
+      );
+
+      // A derived background is the 50% midpoint between the badge color and
+      // white — assert the formula per channel (independent of Color.lerp's
+      // exact rounding), not just that it differs from the badge color.
+      final water = PokemonTypeTheme.styleOf(PokemonTypeId.water);
+      expect(water.backgroundColor.r, closeTo((water.color.r + 1.0) / 2, 0.01));
+      expect(water.backgroundColor.g, closeTo((water.color.g + 1.0) / 2, 0.01));
+      expect(water.backgroundColor.b, closeTo((water.color.b + 1.0) / 2, 0.01));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

PR3 — the last **Foundation & Setup** slice: the §10 design system. Centralizes all theme tokens so later screens (T-18+) build on one source.

- **`lib/core/pokemon/pokemon_type_id.dart`** — the 18-type `PokemonTypeId` enum, placed in `core/` (not `app/theme/`) so the theme now and the domain layer later can both depend on it without a domain→presentation inversion.
- **`lib/app/theme/`** — `AppColors` (§10.1), `AppTypography` (§10.2 on SF Pro Display), `AppTheme` (`ColorScheme` + `ThemeData`), and `PokemonTypeTheme`.
- **`PokemonTypeTheme.styleOf(type)`** → `({Color color, Color backgroundColor})` for all 18 types: exact §10.3 badge hexes; exact backgrounds for Grass/Fire and a **provisional** 50%-toward-white tint for the other 16 (reconciled against the Figma "Background Type" variables in T-18). Type icons deferred to T-18 (record→class migration planned).
- Theme wired globally via `MaterialApp(theme: AppTheme.light)`.

## Acceptance (T-04)

- [x] `ThemeData` defined with §10.1 base colors + SF Pro Display typography.
- [x] `PokemonTypeTheme` covers all 18 types with §10.3 colors (+ derived bg tints for the 16).
- [x] Theme applied globally; color-by-type verified in a widget test (RN-04).

## Notes for reviewers

- All 18 §10.3 badge hexes + the two §10.3 backgrounds were verified bit-for-bit against Tech Spec §10.
- The `textTheme` slot mapping was intentionally **not** added (it would be speculative without a widget consumer); widgets use the named `AppTypography` styles directly — the single canonical typography path. The theme sets the font family globally.

## Test plan

- [x] `dart format --set-exit-if-changed .` passes
- [x] `dart analyze --fatal-infos --fatal-warnings` → 0 issues
- [x] `flutter test --coverage` green (executable theme files 100% covered)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)